### PR TITLE
Add dependabot dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,28 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      aws-sdk-go-v2:
+      # AWS SDK + smithy-go bump in lockstep and rewrite the same go.mod
+      # lines. github.com/aws/* covers aws-sdk-go-v2* and smithy-go.
+      aws:
         patterns:
-          - "github.com/aws/aws-sdk-go-v2*"
+          - "github.com/aws/*"
+      # disgo and its sibling modules (omit, snowflake, json, godave) are
+      # released together by the disgoorg org.
+      disgoorg:
+        patterns:
+          - "github.com/disgoorg/*"
+      # golang.org/x modules are versioned together upstream.
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      # Collapse the routine minor/patch action bumps into one PR.
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Adds dependabot `groups` so coherent dependency families update together in a single PR instead of as separate, mutually-conflicting PRs.

**gomod:**
- `aws` → `github.com/aws/*` — the aws-sdk-go-v2 modules **and** `smithy-go` (a sibling that bumps with the SDK; a narrower `aws-sdk-go-v2*` pattern would miss it).
- `disgoorg` → `github.com/disgoorg/*` — disgo + its siblings (`omit`, `snowflake/v2`, `json/v2`, `godave`), released together by the org.
- `golang-x` → `golang.org/x/*` — versioned together upstream.

**github-actions:**
- `actions` → all minor/patch action bumps in one PR (majors still come individually).

## Why

The AWS SDK modules all rewrite the same `go.mod`/`go.sum` lines, so ungrouped they arrive as separate PRs (e.g. #197 + #199) that conflict with each other — merging one forces a rebase on the other. The disgoorg and x families have the same problem. This batch of dependabot PRs (#193–199) would have been ~3 PRs instead of 7 under this config.

Single-module deps (golang-lru, gorilla/websocket, klauspost/compress, go-csync) are intentionally left ungrouped — they bump independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)