### PR TITLE
SHA-pin actions in depcheck.yaml

### DIFF
--- a/.github/workflows/depcheck.yaml
+++ b/.github/workflows/depcheck.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 


### PR DESCRIPTION
Aligns `depcheck.yaml` with `build-test-push.yaml`, which already pins every action to a commit SHA with a version comment.

- `actions/checkout@v6` → `@de0fac2e…` (same pin used in build-test-push.yaml)
- `actions/dependency-review-action@v5` → `@a1d282b3…` (v5.0.0)

Dependabot continues to bump these — it reads the `# vX` comment and updates both the SHA and the comment together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)