### PR TITLE
Switch dependabot to weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       # AWS SDK + smithy-go bump in lockstep and rewrite the same go.mod
       # lines. github.com/aws/* covers aws-sdk-go-v2* and smithy-go.
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       # Collapse the routine minor/patch action bumps into one PR.
       actions:


### PR DESCRIPTION
**What**
Dependabot interval monthly → weekly for all three ecosystems (docker, gomod, github-actions). Weekly runs default to Monday.

**Why**
Pairs with a weekly scheduled Claude routine that reviews, tests, and merges the resulting PRs every Tuesday — smaller, fresher batches per cycle.

**Testing**
Config-only; dependabot validates on merge.