### PR TITLE
Pin CI runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
       fail-fast: true
@@ -53,7 +53,7 @@ jobs:
           - image: sadbox/sprobot
             target: prod
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             cache-scope: publish-bot-amd64
           - image: sadbox/sprobot
             target: prod
@@ -63,7 +63,7 @@ jobs:
           - image: sadbox/sprobot-web
             target: prodweb
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             cache-scope: publish-web-amd64
           - image: sadbox/sprobot-web
             target: prodweb
@@ -73,7 +73,7 @@ jobs:
           - image: sadbox/stickybot
             target: prodstickybot
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             cache-scope: publish-stickybot-amd64
           - image: sadbox/stickybot
             target: prodstickybot
@@ -83,7 +83,7 @@ jobs:
           - image: sadbox/threadbot
             target: prodthreadbot
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             cache-scope: publish-threadbot-amd64
           - image: sadbox/threadbot
             target: prodthreadbot
@@ -137,7 +137,7 @@ jobs:
 
   publish-merge:
     needs: [publish-build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/depcheck.yaml
+++ b/.github/workflows/depcheck.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
**What**
`runs-on: ubuntu-latest` → `ubuntu-24.04` in both workflows (arm runners were already pinned to `ubuntu-24.04-arm`).

**Why**
Standardizing runner pinning across all repos so runner-image upgrades are deliberate, reviewed events instead of silent `-latest` rollovers. The weekly dependency routine now checks for newer stable runner images and proposes bumps as tested PRs.

**Testing**
CI on this PR runs on the pinned runners.