### PR TITLE
Split CI/CD into test.yaml and publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,9 @@
-name: sprobot build, test, and maybe push
+name: publish
 
 on:
   push:
-    branches-ignore: # Dependabot branches get ran through pull_request
-      - 'dependabot/**'
-  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 5 * * 1,3,5'
 
@@ -13,40 +12,10 @@ permissions:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-      fail-fast: true
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Build test image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          push: false
-          load: true
-          tags: sprobot-test
-          target: test
-          platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
-
-      - name: Run vet and tests
-        run: docker run --platform ${{ matrix.platform }} sprobot-test
+    uses: ./.github/workflows/test.yaml
 
   publish-build:
     needs: [test]
-    if: startsWith(github.ref, 'refs/heads/main')
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main # main pushes are tested via publish.yaml's workflow_call
+      - 'dependabot/**' # Dependabot branches get ran through pull_request
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+      fail-fast: true
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          push: false
+          load: true
+          tags: sprobot-test
+          target: test
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Run vet and tests
+        run: docker run --platform ${{ matrix.platform }} sprobot-test


### PR DESCRIPTION
**What**
Replaces `build-test-push.yaml` with `test.yaml` (`pull_request` + non-main `push` + `workflow_call`) and `publish.yaml` (`push` to main + cron), where publish calls test as a reusable workflow and gates on it.

**Why**
PR check runs listed 12 skipped publish jobs. Splitting CI from CD removes the noise while keeping the same guarantee (images publish only from a green main). Test matrix is defined once via `workflow_call`.

**Testing**
This PR runs the new test.yaml; publish.yaml runs on merge to main — verify the publish run goes green end-to-end after merging.